### PR TITLE
Migrate to new shared mlock

### DIFF
--- a/scripts/bismark-measure-active
+++ b/scripts/bismark-measure-active
@@ -208,9 +208,7 @@ if [ $((count % DNS_FQ)) -eq 0 ]; then
 fi
 
 ## Serial measurements ##
-if [ ! -e /tmp/bismark/var/mlock ]; then 
-	# Set measure lock
-	echo $(date +%s) > /tmp/bismark/var/mlock
+if acquire_active_measurements_lock netperf prober ITGRecv ITGSend; then
 	# Bitrate
 	if [ $(( (count + MOFFSET) % BR_DW_FQ)) -eq 0 ]; then
 		# Downstream bitrate using NETPERF
@@ -277,15 +275,10 @@ if [ ! -e /tmp/bismark/var/mlock ]; then
 	fi
 
 	# Release measure lock
-	rm /tmp/bismark/var/mlock
+	release_active_measurments_lock
 else
-	# Check lock
-	locktime=$(cat /tmp/bismark/var/mlock)
-	currtime=$(date +%s)
-	if [ $((currtime - locktime)) -gt 400  ]; then
-		killall netperf prober ITGRecv ITGSend
-		rm /tmp/bismark/var/mlock
-	fi
+	# Check if lock has expired
+	expire_active_measurements_lock
 fi
 
 # XML file footer

--- a/scripts/bismark-measure-wrapper
+++ b/scripts/bismark-measure-wrapper
@@ -9,18 +9,18 @@
 
 utime=`awk -F'[ .]' '{print $1}' /proc/uptime`
 LOCKFILE=/tmp/bismark/var/measurelock  # lockfile for bismark-measure-wrapper
-MLOCKFILE=/tmp/bismark/var/mlock  # lockfile for server-scheduled tests run by bismark-measure-active
 
 if [ -e $LOCKFILE ]; then
-	ntime=`date +%s`
-	ctime=`cat $LOCKFILE`
-	if [ $((ntime - ctime)) -gt $MAX_TEST_DURATION ]; then
-		kill -9 `ps aux | grep bismark-measure-active | awk -F" " '!/grep/{print $1}'`
-		kill -9 `ps aux | grep "$DEVICE_ID".sh | awk -F" " '!/grep/{print $1}'`
-		rm $LOCKFILE $MLOCKFILE /tmp/bismark/data/* /tmp/bismark/active/*.xml
-	fi
+    ntime=`date +%s`
+    ctime=`cat $LOCKFILE`
+    if [ $((ntime - ctime)) -gt $MAX_TEST_DURATION ]; then
+        pkill -9 -f bismark-measurement-active
+        pkill -9 -f ${DEVICE_ID}.sh
+        rm $LOCKFILE /tmp/bismark/data/* /tmp/bismark/active/*.xml
+        expire_active_measurements_lock
+    fi
 else
-	if [ $(( (utime/60)%ACTIVE_MEASUREMENT_FQ )) -eq 0 ]; then
+    if [ $(( (utime/60)%ACTIVE_MEASUREMENT_FQ )) -eq 0 ]; then
         #wget -O /tmp/bismark/local-active.conf $ACTIVE_CONF_URL
         dl_file $ACTIVE_CONF_URL /tmp/bismark/local-active.conf
         #wget -O /tmp/bismark/ping_targets.list $PING_TARGETS_URL
@@ -30,13 +30,13 @@ else
         dl_file $MSERVERS_URL /tmp/bismark/mservers.list 
         dl_file $PTR_TARGETS_URL /tmp/bismark/paristraceroute_targets.list
         dl_file $SYSCTL_URL /tmp/bismark/sysctl.conf
-		date +%s > $LOCKFILE
-		"$BROOT"/usr/bin/bismark-measure-active
-		rm $LOCKFILE
-	fi
-	if [ $(( (utime/60)%SCRIPT_MEASUREMENT_FQ )) -eq 0 ]; then
-		date +%s > $LOCKFILE
-		/tmp/bismark/"$DEVICE_ID".sh
-		rm $LOCKFILE
-	fi
+        date +%s > $LOCKFILE
+        "$BROOT"/usr/bin/bismark-measure-active
+        rm $LOCKFILE
+    fi
+    if [ $(( (utime/60)%SCRIPT_MEASUREMENT_FQ )) -eq 0 ]; then
+        date +%s > $LOCKFILE
+        /tmp/bismark/"$DEVICE_ID".sh
+        rm $LOCKFILE
+    fi
 fi


### PR DESCRIPTION
This will let other experiments reserve the uplink for active measurements.

This change only migrates the mlock to a new shared lock. It doesn't fix existing locking problems with DITG.

I've tested the functions on x86. I haven't tested my other modifications yet:

```
sburnett@univers:~/git/bismark$ source device/OpenWrt_common/lib/functions.inc.sh 
sburnett@univers:~/git/bismark$ ACTIVE_MEASUREMENTS_LOCK_FILE=/tmp/active-lock
sburnett@univers:~/git/bismark$ ACTIVE_MEASUREMENTS_MAX_DURATION_SECONDS=3 

sburnett@univers:~/git/bismark$ acquire_active_measurements_lock; echo $?
0  # Acquire succeeded.
sburnett@univers:~/git/bismark$ acquire_active_measurements_lock; echo $?
acquire_active_measurements_lock:2: file exists: /tmp/active-lock
1  # Acquire failed because lock already acquired.

sburnett@univers:~/git/bismark$ release_active_measurments_lock; echo $?
0  # Lock released.
sburnett@univers:~/git/bismark$ release_active_measurments_lock; echo $?
rm: can't remove '/tmp/active-lock': No such file or directory
1  # Lock cannot be released because it was already acquired.

sburnett@univers:~/git/bismark$ acquire_active_measurements_lock; echo $? 
0
sburnett@univers:~/git/bismark$ sleep 15
sburnett@univers:~/git/bismark$ expire_active_measurements_lock; echo $?  
0
sburnett@univers:~/git/bismark$ acquire_active_measurements_lock; echo $? 
0  # Acquire succeeded because expire_active_measurements_lock released the lock after 10 seconds.

sburnett@univers:~/git/bismark$ sleep 3
sburnett@univers:~/git/bismark$ expire_active_measurements_lock; echo $? 
0
sburnett@univers:~/git/bismark$ acquire_active_measurements_lock; echo $? 
acquire_active_measurements_lock:2: file exists: /tmp/active-lock
1  # Acquire failed because expire_acitve_measurements_lock didn't release the lock after 3 seconds.
```
